### PR TITLE
fix requirements, use sh if no bash

### DIFF
--- a/docker/minio/create-bucket.sh
+++ b/docker/minio/create-bucket.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Configure MinIO Client
 mc alias set minioserver http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
 

--- a/docker/mlflow/requirements.txt
+++ b/docker/mlflow/requirements.txt
@@ -1,3 +1,3 @@
-mlflow==2.11.0
-psycopg2-binary==2.9.9
-boto3==1.34.55
+mlflow
+psycopg2-binary
+boto3


### PR DESCRIPTION
A had an issue with parsing the characters of the requirements.txt using this repo - so suggest the following changes in the PR.

For using this example on a device without bash I would suggest changing to the shebang to sh on the minio script.